### PR TITLE
Gameplay & Screen Layout Enhancement

### DIFF
--- a/global/config.gd
+++ b/global/config.gd
@@ -5,6 +5,10 @@ const PLAYER_COLORS: Dictionary = {
 									  1: [Color(1.0, 0.0, 0.894, 1.0), Color(0.733, 0.0, 0.655, 1.0)], # Pink
 									  2: [Color(0.0, 0.722, 1.0, 1.0), Color(0.0, 0.529, 0.733, 1.0)]   # Blue
 								  }
+const PLAYER_CONTROLS_TEXT: Dictionary = {
+											 1: "ASWD to move, Q to launch projectile",
+											 2: "JIKL to move, U to launch projectile",
+										 }
 # player ship threshold that's rotation only (strafe) before applying force
 const PLAYER_SHIP_STRAFE_THRESHOLD_MSEC: float = 500
 # player ship threshold of how long to wait between launching projectile explosives
@@ -20,11 +24,11 @@ const PLAYER_COLLECT_GEM_VALUE: int  = 1
 const PLAYER_DISABLE_SHIP_VALUE: int = 0
 # Formatting template for player input
 const player_input_mapping_format: Dictionary = {
-											 "left": "p%d_left",
-											 "right": "p%d_right",
-											 "up": "p%d_up",
-											 "down": "p%d_down",
-											 "action_a": "p%d_action_a",
-										 }
+													"left": "p%d_left",
+													"right": "p%d_right",
+													"up": "p%d_up",
+													"down": "p%d_down",
+													"action_a": "p%d_action_a",
+												}
 
 

--- a/global/config.gd
+++ b/global/config.gd
@@ -18,9 +18,9 @@ const PLAYER_SHIP_PROJECTILE_EXPLOSIVE_INITIAL_VELOCITY: float = 200.0
 const PLAYER_SHIP_PROJECTILE_EXPLOSIVE_ACCELERATION: float     = 500.0
 const PLAYER_SHIP_PROJECTILE_EXPLOSIVE_MAX_VELOCITY: float     = 2000.0
 # player initial score
-const PLAYER_INITIAL_SCORE: int      = 5
+const PLAYER_INITIAL_SCORE: int      = 3
 const PLAYER_VICTORY_SCORE: int      = 10
-const PLAYER_COLLECT_GEM_VALUE: int  = 1
+const PLAYER_COLLECT_GEM_VALUE: int  = 2
 const PLAYER_DISABLE_SHIP_VALUE: int = 0
 # Formatting template for player input
 const player_input_mapping_format: Dictionary = {

--- a/global/game.gd
+++ b/global/game.gd
@@ -26,7 +26,7 @@ signal player_ready_updated
 # Check if the player can launch a projectile
 func player_can_launch_projectile(player_num: int) -> bool:
 	if score.has(player_num):
-		return score[player_num] > 1
+		return score[player_num] > 0
 	else:
 		print("No score found for player_num: ", player_num)
 		return false

--- a/models/player/home.gd
+++ b/models/player/home.gd
@@ -2,7 +2,7 @@ class_name Home
 extends Node2D
 
 # Constants
-const COLOR_ALPHA_RATIO: float = 0.3
+const COLOR_ALPHA_RATIO: float = 0.6
 
 
 # Player number to identify the home

--- a/models/player/ready.gd
+++ b/models/player/ready.gd
@@ -15,10 +15,12 @@ var input_mapping: Dictionary = {
 
 
 
+
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	_set_player_name()
 	_set_color()
+	_set_player_controls_text()
 	# Set up input mapping for player
 	for key in input_mapping.keys():
 		var action_name: String = Config.player_input_mapping_format[key] % player_num
@@ -30,16 +32,25 @@ func _ready() -> void:
 
 # Set the name of the player based on player_num
 func _set_player_name() -> void:
-	$Text.set_text("Player " + str(player_num))
+	$PlayerNameText.set_text("Player " + str(player_num))
 	pass
 
 
 # Set the colors of the ship based on player_num
 func _set_color() -> void:
 	if player_num in Config.PLAYER_COLORS:
-		$Text.set("theme_override_colors/default_color", Util.color_at_sv_ratio(Config.PLAYER_COLORS[player_num][0], READY_COLOR_SV_RATIO if is_ready else UNREADY_COLOR_SV_RATIO))
+		$PlayerNameText.set("theme_override_colors/default_color", Util.color_at_sv_ratio(Config.PLAYER_COLORS[player_num][0], READY_COLOR_SV_RATIO if is_ready else UNREADY_COLOR_SV_RATIO))
 	else:
 		print("No colors found for player_num: ", player_num)
+	pass
+
+
+# Set the controls text based on player_num
+func _set_player_controls_text() -> void:
+	if player_num in Config.PLAYER_CONTROLS_TEXT:
+		$PlayerControlsText.set_text(Config.PLAYER_CONTROLS_TEXT[player_num])
+	else:
+		print("No controls text found for player_num: ", player_num)
 	pass
 
 	

--- a/models/player/ready.tscn
+++ b/models/player/ready.tscn
@@ -1,16 +1,62 @@
-[gd_scene load_steps=3 format=3 uid="uid://dvo0oiws54t1m"]
+[gd_scene load_steps=6 format=3 uid="uid://dvo0oiws54t1m"]
 
 [ext_resource type="Script" uid="uid://c2fge45tdrxy1" path="res://models/player/ready.gd" id="1_i5n61"]
 [ext_resource type="FontFile" uid="uid://dblvrdtyp1jsa" path="res://assets/fonts/Montserrat/static/Montserrat-Black.ttf" id="2_gkuhg"]
+[ext_resource type="FontFile" uid="uid://vcvw424a0cqr" path="res://assets/fonts/Montserrat/static/Montserrat-SemiBold.ttf" id="3_1pvfr"]
+[ext_resource type="FontFile" uid="uid://bm8bvpfu88aux" path="res://assets/fonts/Montserrat/static/Montserrat-Regular.ttf" id="4_vokxs"]
+[ext_resource type="FontFile" uid="uid://csk5t783aicvv" path="res://assets/fonts/Montserrat/static/Montserrat-ExtraBoldItalic.ttf" id="5_rgc1c"]
 
 [node name="Score" type="Node2D"]
 script = ExtResource("1_i5n61")
 
-[node name="Text" type="RichTextLabel" parent="."]
-offset_left = -145.0
-offset_top = -27.0
-offset_right = 145.0
-offset_bottom = 27.0
+[node name="GameTitleText" type="RichTextLabel" parent="."]
+offset_left = -213.0
+offset_top = -9.0
+offset_right = 212.0
+offset_bottom = 63.0
+theme_override_fonts/normal_font = ExtResource("2_gkuhg")
+theme_override_font_sizes/normal_font_size = 40
+text = "BLASTEROIDS!"
+horizontal_alignment = 1
+
+[node name="PlayerControlsText" type="RichTextLabel" parent="."]
+offset_left = -302.0
+offset_top = 52.0
+offset_right = 289.0
+offset_bottom = 103.0
+theme_override_fonts/normal_font = ExtResource("3_1pvfr")
+theme_override_font_sizes/normal_font_size = 24
+text = "ABCD to move, E to launch projectile"
+horizontal_alignment = 1
+
+[node name="InstructionsText" type="RichTextLabel" parent="."]
+offset_left = -255.0
+offset_top = 105.0
+offset_right = 359.0
+offset_bottom = 236.0
+theme_override_fonts/normal_font = ExtResource("4_vokxs")
+theme_override_font_sizes/normal_font_size = 18
+text = "- Launch a projectile, costs 1 point
+- Blow up the blocks containing gems to free the gems
+- Get a freed gem to your zone, collect it for +2 points
+- Projectile hits a ship, disables it for 3 seconds
+- First player to 10 points wins"
+
+[node name="ReadyText" type="RichTextLabel" parent="."]
+offset_left = -351.0
+offset_top = 254.0
+offset_right = 342.0
+offset_bottom = 299.0
+theme_override_fonts/normal_font = ExtResource("5_rgc1c")
+theme_override_font_sizes/normal_font_size = 18
+text = "Hit your launch button to ready up!"
+horizontal_alignment = 1
+
+[node name="PlayerNameText" type="RichTextLabel" parent="."]
+offset_left = -147.0
+offset_top = 287.0
+offset_right = 143.0
+offset_bottom = 341.0
 theme_override_colors/default_color = Color(1, 1, 1, 1)
 theme_override_fonts/normal_font = ExtResource("2_gkuhg")
 theme_override_font_sizes/normal_font_size = 40

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -1,11 +1,7 @@
-[gd_scene load_steps=7 format=3 uid="uid://cmijftuchxf62"]
+[gd_scene load_steps=3 format=3 uid="uid://cmijftuchxf62"]
 
 [ext_resource type="Script" uid="uid://cnw80skrxjv77" path="res://scenes/main.gd" id="1_0pxjd"]
-[ext_resource type="FontFile" uid="uid://dblvrdtyp1jsa" path="res://assets/fonts/Montserrat/static/Montserrat-Black.ttf" id="2_sugp2"]
-[ext_resource type="FontFile" uid="uid://bm8bvpfu88aux" path="res://assets/fonts/Montserrat/static/Montserrat-Regular.ttf" id="3_jyhfs"]
-[ext_resource type="FontFile" uid="uid://vcvw424a0cqr" path="res://assets/fonts/Montserrat/static/Montserrat-SemiBold.ttf" id="3_tbgi4"]
 [ext_resource type="PackedScene" uid="uid://dvo0oiws54t1m" path="res://models/player/ready.tscn" id="4_jyhfs"]
-[ext_resource type="FontFile" uid="uid://csk5t783aicvv" path="res://assets/fonts/Montserrat/static/Montserrat-ExtraBoldItalic.ttf" id="4_tefeu"]
 
 [node name="Main" type="Node2D"]
 script = ExtResource("1_0pxjd")
@@ -16,52 +12,12 @@ offset_right = 1024.0
 offset_bottom = 576.0
 color = Color(0, 0, 0, 1)
 
-[node name="RichTextLabel" type="RichTextLabel" parent="."]
-offset_left = 37.0
-offset_top = 32.0
-offset_right = 413.0
-offset_bottom = 104.0
-theme_override_fonts/normal_font = ExtResource("2_sugp2")
-theme_override_font_sizes/normal_font_size = 50
-text = "Blasteroids!"
-
-[node name="ControlsText" type="RichTextLabel" parent="."]
-offset_left = 39.0
-offset_top = 113.0
-offset_right = 998.0
-offset_bottom = 189.0
-theme_override_fonts/normal_font = ExtResource("3_tbgi4")
-theme_override_font_sizes/normal_font_size = 30
-text = "Player 1 uses ASWD to move, Q to launch projectile
-Player 2 uses JIKL to move, U to launch projectile"
-
-[node name="InstructionsText" type="RichTextLabel" parent="."]
-offset_left = 78.0
-offset_top = 206.0
-offset_right = 975.0
-offset_bottom = 372.0
-theme_override_fonts/normal_font = ExtResource("3_jyhfs")
-theme_override_font_sizes/normal_font_size = 25
-text = "- Spend 1 point to launch a projectile
-- Blow up the blocks containing gems to free the gems
-- Nudge a gem  into your home zone to collect it for 2 points
-- If your projectile hits a ship, disable it for 3 seconds, but lose 3 points
-- Score of 10 points wins, but a score of 0 points loses"
-
-[node name="ReadyText" type="RichTextLabel" parent="."]
-offset_left = 39.0
-offset_top = 417.0
-offset_right = 985.0
-offset_bottom = 463.0
-theme_override_fonts/normal_font = ExtResource("4_tefeu")
-theme_override_font_sizes/normal_font_size = 30
-text = "Players hit your launch buttons to ready up!"
-horizontal_alignment = 1
-
 [node name="ReadyPlayer1" parent="." instance=ExtResource("4_jyhfs")]
-position = Vector2(344, 500)
+position = Vector2(409, 291)
+rotation = 1.5708
 player_num = 1
 
 [node name="ReadyPlayer2" parent="." instance=ExtResource("4_jyhfs")]
-position = Vector2(658, 500)
+position = Vector2(619, 288)
+rotation = -1.5708
 player_num = 2

--- a/scenes/play_game.gd
+++ b/scenes/play_game.gd
@@ -82,8 +82,10 @@ func _game_over(result: GameResult) -> void:
 # Show the modal with the given text and color
 func _show_modal(text: String, color: Color) -> void:
 	$Modal.show()
-	$Modal/Text.text = text
-	$Modal/Text.set("theme_override_colors/default_color", color)
+	$Modal/Text1.text = text
+	$Modal/Text1.set("theme_override_colors/default_color", color)
+	$Modal/Text2.text = text
+	$Modal/Text2.set("theme_override_colors/default_color", color)
 	_pause_game()
 
 
@@ -103,10 +105,10 @@ func _hide_modal() -> void:
 # fact going to win after that projectile explodes, so we need to also test that no projectiles are in play
 func _check_for_game_over() -> void:
 	await _delay(GAME_CHECK_OVER_DELAY)
-	if Game.score[2] == 0 or Game.score[1] == Config.PLAYER_VICTORY_SCORE:
+	if Game.score[1] == Config.PLAYER_VICTORY_SCORE:
 		_game_over(GameResult.PLAYER_1_WINS)
 		return
-	if Game.score[1] == 0 or Game.score[2] == Config.PLAYER_VICTORY_SCORE:
+	if Game.score[2] == Config.PLAYER_VICTORY_SCORE:
 		_game_over(GameResult.PLAYER_2_WINS)
 		return
 	if Game.score[1] == Config.PLAYER_VICTORY_SCORE and Game.score[2] == Config.PLAYER_VICTORY_SCORE:

--- a/scenes/play_game.tscn
+++ b/scenes/play_game.tscn
@@ -33,12 +33,26 @@ position = Vector2(1032, 288)
 shape = SubResource("RectangleShape2D_xet8o")
 
 [node name="Modal" type="Node2D" parent="."]
-visible = false
 z_index = 100
 
-[node name="Text" type="RichTextLabel" parent="Modal"]
-offset_right = 1024.0
-offset_bottom = 576.0
+[node name="Text1" type="RichTextLabel" parent="Modal"]
+offset_left = 512.0
+offset_right = 1088.0
+offset_bottom = 512.0
+rotation = 1.5708
+theme_override_colors/default_color = Color(1, 1, 1, 1)
+theme_override_fonts/normal_font = ExtResource("2_4xfa0")
+theme_override_font_sizes/normal_font_size = 40
+text = "Get Ready! "
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Text2" type="RichTextLabel" parent="Modal"]
+offset_left = 512.0
+offset_top = 576.0
+offset_right = 1088.0
+offset_bottom = 1088.0
+rotation = -1.5708
 theme_override_colors/default_color = Color(1, 1, 1, 1)
 theme_override_fonts/normal_font = ExtResource("2_4xfa0")
 theme_override_font_sizes/normal_font_size = 40


### PR DESCRIPTION
Implements some of #39 Main Screen Design
- two sets of instructions on left/right side, facing each player
- play game screen modal text duplicated on left/right side, facing each player

Closes #45 Allow points to get to zero 
- allow points to get to zero before unable to launch
- no loss for zero points

Also, make player homes more visible