### PR TITLE
Unblocking Game Flow

### DIFF
--- a/global/config.gd
+++ b/global/config.gd
@@ -26,6 +26,7 @@ const BLOCK_ACTIVATION_HEAT_THRESHOLD: float = 0.5
 const BLOCK_INACTIVE_OPACITY: float = 0.38
 const BLOCK_HALF_HEATED_BREAK_SEC: float = BLOCK_HEATED_BREAK_SEC / 2
 const BLOCK_QUART_HEATED_BREAK_SEC: float = BLOCK_HEATED_BREAK_SEC / 4
+const BLOCK_BREAK_HEAT_TRANSFER_RATIO: float = 0.7
 # player ship threshold of how long to wait between launching projectile explosives
 const PROJECTILE_EXPLOSIVE_COOLDOWN_MSEC: float = 500
 # player ship projectile explosive initial velocity, acceleration, and max velocity

--- a/global/config.gd
+++ b/global/config.gd
@@ -22,6 +22,8 @@ const PLAYER_SHIP_HEATED_DISABLED_THRESHOLD_SEC: float = 2.0
 const BLOCK_BREAK_APART_VELOCITY: float = 50
 const BLOCK_HALF_BREAK_APART_VELOCITY: float = BLOCK_BREAK_APART_VELOCITY / 2
 const BLOCK_HEATED_BREAK_SEC: float = 1.0
+const BLOCK_ACTIVATION_HEAT_THRESHOLD: float = 0.5
+const BLOCK_INACTIVE_OPACITY: float = 0.38
 const BLOCK_HALF_HEATED_BREAK_SEC: float = BLOCK_HEATED_BREAK_SEC / 2
 const BLOCK_QUART_HEATED_BREAK_SEC: float = BLOCK_HEATED_BREAK_SEC / 4
 # player ship threshold of how long to wait between launching projectile explosives
@@ -32,8 +34,9 @@ const PROJECTILE_EXPLOSIVE_ACCELERATION: float     = 500.0
 const PROJECTILE_EXPLOSIVE_MAX_VELOCITY: float     = 2000.0
 # pertaining to explosive
 const EXPLOSION_LIFETIME_MSEC: int                         = 1000
-const EXPLOSION_CRITICAL_RADIUS_BLOCK_BREAK_RATIO: float   = 0.5
-const EXPLOSION_CRITICAL_RADIUS_BLOCK_SHATTER_RATIO: float = 0.4
+const EXPLOSION_HEAT_RADIUS_RATIO: float   = 0.7
+const EXPLOSION_CRITICAL_RADIUS_BLOCK_BREAK_RATIO: float   = 0.4
+const EXPLOSION_CRITICAL_RADIUS_BLOCK_SHATTER_RATIO: float = 0.3
 const EXPLOSION_CRITICAL_RADIUS_SHIP_RATIO: float          = 0.4
 const EXPLOSION_FORCE: int                       = 8000
 # player initial score

--- a/models/block/block.gd
+++ b/models/block/block.gd
@@ -21,6 +21,8 @@ const gem_scene: PackedScene   = preload("res://models/gem/gem.tscn")
 
 # Cache reference to heated effect
 @onready var heated_effect: Node2D = $HeatedEffect
+# Cache reference to Shapes
+@onready var shapes: Node2D = $Shapes
 # Preloaded scene for the block quarter shattering
 const shatter_scene: PackedScene = preload("res://models/block/block_quart_shatter.tscn")
 
@@ -31,6 +33,8 @@ func _ready() -> void:
 	add_to_group(Game.BLOCK_GROUP)
 	# Update the heated effect visibility
 	_update_heated_effect()
+	freeze = true
+	shapes.modulate.a = Config.BLOCK_INACTIVE_OPACITY
 	pass
 
 
@@ -109,6 +113,13 @@ func _do_release_gem() -> bool:
 func do_heat(delta: float) -> void:
 	heated_delta += delta
 	pass
+	
+	
+# Activate
+func do_activate() -> void:
+	freeze = false
+	shapes.modulate.a = 1
+	pass	
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -121,11 +132,13 @@ func _process(_delta: float) -> void:
 # If the ship is heated for too long, disable it
 func _update_heat(delta: float) -> void:
 	if heated_delta > 0:
-		heated_sec += delta
+		heated_sec += heated_delta
 		heated_delta = 0.0
 		_update_heated_effect()
 		if heated_sec >= Config.BLOCK_HEATED_BREAK_SEC:
 			call_deferred("do_break")
+		if freeze and heated_sec >= Config.BLOCK_ACTIVATION_HEAT_THRESHOLD:
+			call_deferred("do_activate")
 	elif heated_sec > 0:
 		heated_sec -= delta
 		if heated_sec < 0:

--- a/models/block/block.gd
+++ b/models/block/block.gd
@@ -61,12 +61,14 @@ func do_break(broken_by: Node = null) -> void:
 	half1.position = position
 	half1.linear_velocity = linear_velocity + Vector2(-Config.BLOCK_BREAK_APART_VELOCITY, -Config.BLOCK_BREAK_APART_VELOCITY)
 	half1.half_num = 1
+	half1.do_heat(Config.BLOCK_HALF_HEATED_BREAK_SEC * Config.BLOCK_BREAK_HEAT_TRANSFER_RATIO)
 	# Half 2
 	var half2: Node = half2_scene.instantiate()
 	half2.add_collision_exception_with(self)
 	half2.position = position
 	half2.linear_velocity = linear_velocity + Vector2(Config.BLOCK_BREAK_APART_VELOCITY, Config.BLOCK_BREAK_APART_VELOCITY)
 	half2.half_num = 2
+	half2.do_heat(Config.BLOCK_HALF_HEATED_BREAK_SEC * Config.BLOCK_BREAK_HEAT_TRANSFER_RATIO)
 	# Gem
 	if _do_release_gem():
 		gem.add_collision_exception_with(half1)

--- a/models/block/block.tscn
+++ b/models/block/block.tscn
@@ -23,21 +23,23 @@ script = null
 [node name="CollisionShape2D" type="CollisionPolygon2D" parent="."]
 polygon = PackedVector2Array(-15, -11, -11, -15, 11, -15, 15, -11, 15, 11, 11, 15, -11, 15, -15, 11)
 
-[node name="TriangleUp" type="Polygon2D" parent="."]
-z_index = 5
-position = Vector2(-12, 2)
-color = Color(0.47, 0.47, 0.47, 0.392157)
-polygon = PackedVector2Array(-3, -13, 1, -17, 23, -17, 25, -15, -1, 11, -3, 9)
-
-[node name="TriangleDown" type="Polygon2D" parent="."]
-z_index = 5
-position = Vector2(-12, 2)
-color = Color(0.37, 0.37, 0.37, 0.392157)
-polygon = PackedVector2Array(27, 10, 27, -13, 25, -15, -1, 11, 1, 13, 24, 13)
-
 [node name="HeatedEffect" type="Node2D" parent="."]
 
 [node name="HeatedShape" type="Polygon2D" parent="HeatedEffect"]
 z_index = 5
 position = Vector2(-12, 2)
 polygon = PackedVector2Array(2, -16, 22, -16, 26, -12, 26, 8, 22, 12, 2, 12, -2, 8, -2, -12)
+
+[node name="Shapes" type="Node2D" parent="."]
+
+[node name="TriangleUp" type="Polygon2D" parent="Shapes"]
+z_index = 5
+position = Vector2(-12, 2)
+color = Color(0.47, 0.47, 0.47, 0.392157)
+polygon = PackedVector2Array(-3, -13, 1, -17, 23, -17, 25, -15, -1, 11, -3, 9)
+
+[node name="TriangleDown" type="Polygon2D" parent="Shapes"]
+z_index = 5
+position = Vector2(-12, 2)
+color = Color(0.37, 0.37, 0.37, 0.392157)
+polygon = PackedVector2Array(27, 10, 27, -13, 25, -15, -1, 11, 1, 13, 24, 13)

--- a/models/block/block_half.gd
+++ b/models/block/block_half.gd
@@ -37,11 +37,13 @@ func do_break(broken_by: Node = null) -> void:
 	quartA.add_collision_exception_with(self)
 	quartA.position = position
 	quartA.linear_velocity = linear_velocity + (Vector2(-Config.BLOCK_HALF_BREAK_APART_VELOCITY, 0) if half_num == 1 else Vector2(Config.BLOCK_HALF_BREAK_APART_VELOCITY, 0))
+	quartA.do_heat(Config.BLOCK_QUART_HEATED_BREAK_SEC * Config.BLOCK_BREAK_HEAT_TRANSFER_RATIO)
 	# Quarter B
 	var quartB: Node = (quart_scene_1b if half_num == 1 else quart_scene_2b).instantiate()
 	quartB.add_collision_exception_with(self)
 	quartB.position = position
 	quartB.linear_velocity = linear_velocity + (Vector2(0, -Config.BLOCK_HALF_BREAK_APART_VELOCITY) if half_num == 1 else Vector2(0, Config.BLOCK_HALF_BREAK_APART_VELOCITY))
+	quartB.do_heat(Config.BLOCK_QUART_HEATED_BREAK_SEC * Config.BLOCK_BREAK_HEAT_TRANSFER_RATIO)
 	# Avoid collisions with the block that broke this half
 	if broken_by:
 		quartA.dont_break_by.append(broken_by)

--- a/models/block/block_half.gd
+++ b/models/block/block_half.gd
@@ -78,7 +78,7 @@ func _process(_delta: float) -> void:
 # If the ship is heated for too long, disable it
 func _update_heat(delta: float) -> void:
 	if heated_delta > 0:
-		heated_sec += delta
+		heated_sec += heated_delta
 		heated_delta = 0.0
 		_update_heated_effect()
 		if heated_sec >= Config.BLOCK_HALF_HEATED_BREAK_SEC:

--- a/models/block/block_quart.gd
+++ b/models/block/block_quart.gd
@@ -50,7 +50,7 @@ func _process(_delta: float) -> void:
 # If the ship is heated for too long, disable it
 func _update_heat(delta: float) -> void:
 	if heated_delta > 0:
-		heated_sec += delta
+		heated_sec += heated_delta
 		heated_delta = 0.0
 		_update_heated_effect()
 		if heated_sec >= Config.BLOCK_HALF_HEATED_BREAK_SEC:

--- a/models/player/ship.gd
+++ b/models/player/ship.gd
@@ -243,7 +243,7 @@ func _update_laser(delta: float) -> void:
 # If the ship is heated for too long, disable it
 func _update_heat(delta: float) -> void:
 	if heated_delta > 0:
-		heated_sec += delta
+		heated_sec += heated_delta
 		heated_delta = 0.0
 		_update_heated_effect()
 		if heated_sec >= Config.PLAYER_SHIP_HEATED_DISABLED_THRESHOLD_SEC:


### PR DESCRIPTION
- Blocks are spawned in a Inactive static state, wherein they do not move. Active blocks/gems/ships bounce off the Inactive blocks
- When a block is heated even slightly with a laser, it becomes Active and can move
- When a block is within the range of being touched by an explosion at all, it becomes Active and can move
- When a block/half/quarter is affected by an explosion, it is also heated by an amount inversely proportional to its distance to the center of the explosion
- When a half block is spawned, it starts off mostly heated
- When a quarter block is spawned, it starts off mostly heated

Closes #82